### PR TITLE
Update perceptual_loss.py

### DIFF
--- a/src/loss/perceptual_similarity/perceptual_loss.py
+++ b/src/loss/perceptual_similarity/perceptual_loss.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from skimage.measure import compare_ssim
+from skimage.metrics import structural_similarity as compare_ssim
 import torch
 from torch.autograd import Variable
 


### PR DESCRIPTION
skimage.measure.compare_ssim is removed in skimage 0.18 release and after updated by skimage.metrics submodule