### PR TITLE
Fix typo in learning rate decay logging.

### DIFF
--- a/src/helpers/utils.py
+++ b/src/helpers/utils.py
@@ -77,7 +77,7 @@ def update_lr(args, optimizer, itr, logger):
         old_lr = param_group['lr']
         if old_lr != lr:
             logger.info('=============================')
-            logger.info(f'Changing learning rate {olf_lr} -> {lr}')
+            logger.info(f'Changing learning rate {old_lr} -> {lr}')
             param_group['lr'] = lr
 
 def setup_generic_signature(args, special_info):


### PR DESCRIPTION
Hello Justin, I hope you're doing well. I came across a small typo that caused the entire training process to halt. It could potentially waste several iterations of training.

The error is triggered when a new Adam optimizer setup (other than the one in the pre-trained model) is provided and occurs when the learning rate is updated.

It is truly amazing to find a PyTorch implementation of HiFiC, and I appreciate your time and efforts in maintaining this project! 