### PR TITLE
Fix ImportError in perceptual_loss.py: Update compare_ssim Import

### DIFF
--- a/src/loss/perceptual_similarity/perceptual_loss.py
+++ b/src/loss/perceptual_similarity/perceptual_loss.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from skimage.measure import compare_ssim
+from skimage.metrics import structural_similarity as compare_ssim
 import torch
 from torch.autograd import Variable
 


### PR DESCRIPTION
This pull request fixes an ImportError in the perceptual_loss.py file located in the src/loss/perceptual_similarity/ directory.

Impact:

	•	This change resolves the ImportError, ensuring that the perceptual_loss.py script can execute without issues.
	•	It brings the code in line with the updated scikit-image library, improving compatibility and stability.

Please review the changes and merge them if they align with the project’s goals.

Let me know if you need any more help!